### PR TITLE
Instagram Loading Followers Fix

### DIFF
--- a/lib/social_profile/browser_parsers/gmail_parser.rb
+++ b/lib/social_profile/browser_parsers/gmail_parser.rb
@@ -21,7 +21,7 @@ module SocialProfile
           "//span[contains(@email, 'security@mail.instagram.com')]"
         assert_selector(:xpath, email_path, wait: 30)
         first(:xpath, email_path).click
-        with_error_handling(return_on_fail: '') { first('font').text }
+        with_error_handling(return_on_fail: '') { all('font', wait: 5).last.text }
       end
 
       private
@@ -34,6 +34,7 @@ module SocialProfile
         wait_if_loading
         find(:xpath, "//input[contains(@type, '#{title}')]", visible: true, wait: 5).set(value)
         find(:xpath, "//*[contains(@name, 'signIn') or contains(@id, 'Next')]").click
+        wait_if_loading
       end
 
       def wait_if_loading

--- a/lib/social_profile/version.rb
+++ b/lib/social_profile/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SocialProfile
-  VERSION = "0.3.6"
+  VERSION = "0.3.7"
 end

--- a/spec/browser_parsers/gmail_parser_spec.rb
+++ b/spec/browser_parsers/gmail_parser_spec.rb
@@ -36,7 +36,7 @@ describe SocialProfile::BrowserParsers::GmailParser do
         allow(parser).to receive(:login)
         allow(parser).to receive(:assert_selector)
         allow(parser).to receive(:first).and_return(double(click: nil))
-        allow(parser).to receive(:first).with('font').
+        allow(parser).to receive(:all).with('font', wait: 5).
           and_raise Selenium::WebDriver::Error::StaleElementReferenceError
       end
 

--- a/spec/browser_parsers/instagram_parser_spec.rb
+++ b/spec/browser_parsers/instagram_parser_spec.rb
@@ -25,11 +25,26 @@ describe SocialProfile::BrowserParsers::InstagramParser do
         allow(parser).to receive(:click_button)
         allow(parser).to receive(:assert_no_selector)
         allow(parser).to receive(:fill_in)
+        allow(parser).to receive(:person_confirmation?)
       end
 
       it 'verifies user' do
         expect(parser).to receive(:verification_process)
         expect { parser.login }.not_to raise_error
+      end
+    end
+
+    context 'when instagram requires to confirm person' do
+      before do
+        allow(parser).to receive(:visit)
+        allow(parser).to receive(:accept_alert_if_present)
+        allow(parser).to receive(:person_confirmation?).and_return(true)
+        allow(parser).to receive(:logged_in?).and_return(true)
+      end
+
+      it 'clicks "This Was Me" button' do
+        expect(parser).to receive(:click_button).with('This Was Me')
+        expect(parser.login).to be_truthy
       end
     end
   end


### PR DESCRIPTION
- Sometimes followers list is loading not immediately after click to
  'followers', so we must be sure that followers list already loaded
  before scroll down
- Fixed case when instagram requires to confirm person
- Stability improvement (added waits and asserts)